### PR TITLE
How to import / use a css file instead of a js file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "owc-dev-server": "^0.3.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.10.0",
+    "rollup-plugin-css-only": "^1.0.0",
     "rollup-plugin-node-resolve": "^4.0.0"
   },
   "main": "src/my-credit-card.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import resolve from 'rollup-plugin-node-resolve';
+import css from 'rollup-plugin-css-only'
 
 export default {
   // If using any exports from a symlinked project, uncomment the following:
@@ -10,6 +11,7 @@ export default {
 		sourcemap: true
 	},
 	plugins: [
-        resolve()
+				resolve(),
+				css({ output: false })
     ]
 };

--- a/src/MyCreditCard.js
+++ b/src/MyCreditCard.js
@@ -1,5 +1,5 @@
-import { html, css, LitElement } from 'lit-element';
-import {myCreditCardStyle} from  './my-credit-card.style';
+import { html, LitElement } from 'lit-element';
+import myCreditCardStyle from './my-credit-card.style.css';
 
 export default class MyCreditCard extends LitElement {
 

--- a/src/my-credit-card.style.css
+++ b/src/my-credit-card.style.css
@@ -1,7 +1,4 @@
-import { css } from 'lit-element';
-
-export const myCreditCardStyle = css`
-:host{
+:host {
     display: block;
     font-family: sans-serif;
 }
@@ -220,4 +217,3 @@ fieldset {
     border: none;
     cursor: pointer;
 }
-`;


### PR DESCRIPTION
This pull request shows an example about how to import a `css` file instead of a `js` file. 

This idea is from @zmencay who gave me an example from a class she attended (on the class, they used sass).

**A minor change will be necessary** (not included). The demo should load the built file instead of the src file:

```
<script type="module">
    import { html, render } from 'https://unpkg.com/lit-html?module'; // workaround until owc-dev-server supports html
    import '../dist/my-credit-card.js';

    const title = 'My LitElement Bank';
    render(html`
      <my-credit-card .title=${title}>
      </my-credit-card>
    `, document.querySelector('#demo'));
  </script>
```